### PR TITLE
feat: adiciona testes de dados(VADER D) para endpoints users e transfers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1657,7 +1657,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -2027,7 +2026,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -2606,7 +2604,6 @@
       "integrity": "sha512-1jYAaY8x0kAZ0XszLWu14pzsf4KV740Gld4HXkhNTXwcHx4AUEDkPzgEHg9CM5dVcW+zv036tjpsEbLraPJj4w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",

--- a/test/rest/controller/transferController.test.js
+++ b/test/rest/controller/transferController.test.js
@@ -125,3 +125,4 @@ describe('Transfer Controller', () => {
         });
     });
 });
+

--- a/test/rest/external/transferExternal.test.js
+++ b/test/rest/external/transferExternal.test.js
@@ -8,7 +8,7 @@ use(chaiExclude)
 
 require('dotenv').config();
 
-// Testes para external do enpoint de transferências
+// Testes para external do endpoint de transferências
 describe('Transfer', () => {
     describe('POST /transfers', () => {
         before(async () => {
@@ -46,7 +46,9 @@ describe('Transfer', () => {
             expect(resposta.body).to.have.property('message', 'Token não fornecido.');
         });
 
-    const testesDeErrosDeNegocio = require('../fixture/requisicoes/transferencias/postTransferWithErrors.json');
+   
+        
+        const testesDeErrosDeNegocio = require('../fixture/requisicoes/transferencias/postTransferWithErrors.json');
         testesDeErrosDeNegocio.forEach(teste => {
             it(`Testando a regra relacionada a ${teste.nomeDoTeste}`, async () => {
                 const postTransfer = require('../fixture/requisicoes/transferencias/postTransfer.json');
@@ -59,11 +61,20 @@ describe('Transfer', () => {
                 expect(resposta.body).to.have.property('error', teste.mensagemEsperada)
             });
         });
-    });
 
-    describe('GET /transfers', () => {
+        
+        
+
+        
+
+});
+
+
+
+
+describe('GET /transfers', () => {
         it('Quando consulto a lista de transferências autenticado, recebo um array', async () => {
-            const postLogin = require('../fixture/requisicoes/login/postLogin.json');
+            const postLogin = require('../fixture/requisicoes/login/postLogin.json')
             const respostaLogin = await request(process.env.BASE_URL_REST)
                 .post('/users/login')
                 .send(postLogin);
@@ -83,5 +94,71 @@ describe('Transfer', () => {
             expect(resposta.status).to.equal(401);
             expect(resposta.body).to.have.property('message', 'Token não fornecido.');
         });
+});
+
+
+
+// Teste de Dados - endpoint de transferências - POST
+const testesDeDados = require('../fixture/requisicoes/transferencias/postTransferData.json');
+
+describe('POST /transfers - Testes de Dados', () => {
+    testesDeDados.forEach(teste => {
+        it(`Quando envio dados inválidos: ${teste.nomeDoTeste}`, async () => {
+            const resposta = await request(process.env.BASE_URL_REST)
+                .post('/transfers')
+                .set('Authorization', `Bearer ${token}`)
+                .send(teste.postTransfer);
+
+            expect(resposta.status).to.equal(teste.statusCode);
+            expect(resposta.body).to.have.property('error', teste.mensagemEsperada);
+        });
     });
+});
+
+// Teste de Dados - endpoint de transferências - GET
+describe('GET /transfers - Testes de Dados', () => {
+    let token;
+
+    before(async () => {
+        const postLogin = require('../fixture/requisicoes/login/postLogin.json');
+        const respostaLogin = await request(process.env.BASE_URL_REST)
+            .post('/users/login')
+            .send(postLogin);
+
+        token = respostaLogin.body.token;
+    });
+
+    it('Deve retornar um array de transferências', async () => {
+        const resposta = await request(process.env.BASE_URL_REST)
+            .get('/transfers')
+            .set('Authorization', `Bearer ${token}`);
+
+        expect(resposta.status).to.equal(200);
+        expect(resposta.body).to.be.an('array');
+    });
+
+    it('Cada transferência deve ter os campos corretos e tipos válidos', async () => {
+        const resposta = await request(process.env.BASE_URL_REST)
+            .get('/transfers')
+            .set('Authorization', `Bearer ${token}`);
+
+        resposta.body.forEach(transfer => {
+            expect(transfer).to.have.property('from').that.is.a('string');
+            expect(transfer).to.have.property('to').that.is.a('string');
+            expect(transfer).to.have.property('value').that.is.a('number');
+            expect(transfer).to.have.property('date').that.is.a('string'); // ISO date
+        });
+    });
+
+    it('Se não enviar token, deve retornar erro 401', async () => {
+        const resposta = await request(process.env.BASE_URL_REST)
+            .get('/transfers');
+
+        expect(resposta.status).to.equal(401);
+        expect(resposta.body).to.have.property('message', 'Token não fornecido.');
+    });
+
+    
+});
+
 });

--- a/test/rest/external/userExternal.test.js
+++ b/test/rest/external/userExternal.test.js
@@ -80,4 +80,31 @@ describe('User', () => {
             expect(resposta.body).to.be.an('array');
         });
     });
+
+    
+    
+   // Teste de Dados - endpoint de user - POST
+    const testesDeDados = require('../fixture/requisicoes/users/postUserData.json');
+
+    testesDeDados.forEach(teste => {
+    it(`Quando envio dados inválidos ou válidos: ${teste.nomeDoTeste}`, async () => {
+        const resposta = await request(process.env.BASE_URL_REST)
+            .post('/users/register')
+            .send(teste.postUser);
+
+        expect(resposta.status).to.equal(teste.statusCode);
+
+        if (teste.statusCode === 201) {
+            expect(resposta.body).to.have.property('username', teste.postUser.username);
+            expect(resposta.body).to.have.property('favorecidos').that.is.an('array');
+        } else {
+            expect(resposta.body).to.have.property('error', teste.mensagemEsperada);
+        }
+    });
+});
+
+
+
+
+
 });

--- a/test/rest/fixture/requisicoes/login/postLoginData.json
+++ b/test/rest/fixture/requisicoes/login/postLoginData.json
@@ -1,0 +1,42 @@
+[
+  {
+    "nomeDoTeste": "Username excede 50 caracteres",
+    "postUser": {
+      "username": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "password": "123456",
+      "favorecidos": ["julio", "priscila"]
+    },
+    "statusCode": 400,
+    "mensagemEsperada": "Username inválido"
+  },
+  {
+    "nomeDoTeste": "Password menor que 6 caracteres",
+    "postUser": {
+      "username": "usuarioTeste",
+      "password": "123",
+      "favorecidos": ["julio"]
+    },
+    "statusCode": 400,
+    "mensagemEsperada": "Senha inválida"
+  },
+  {
+    "nomeDoTeste": "Favorecidos não é array",
+    "postUser": {
+      "username": "usuarioTeste",
+      "password": "123456",
+      "favorecidos": "julio"
+    },
+    "statusCode": 400,
+    "mensagemEsperada": "Favorecidos deve ser um array"
+  },
+  {
+    "nomeDoTeste": "Usuário válido",
+    "postUser": {
+      "username": "usuarioTesteValido",
+      "password": "123456",
+      "favorecidos": ["julio", "priscila"]
+    },
+    "statusCode": 201,
+    "mensagemEsperada": "Usuário criado com sucesso"
+  }
+]

--- a/test/rest/fixture/requisicoes/transferencias/postTransfer.json
+++ b/test/rest/fixture/requisicoes/transferencias/postTransfer.json
@@ -3,3 +3,4 @@
     "to": "priscila",
     "value": 100
 }
+

--- a/test/rest/fixture/requisicoes/transferencias/postTransferData.json
+++ b/test/rest/fixture/requisicoes/transferencias/postTransferData.json
@@ -1,0 +1,32 @@
+[
+  {
+    "nomeDoTeste": "Campo 'from' excede 50 caracteres",
+    "postTransfer": {
+      "from": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "to": "priscila",
+      "value": 100
+    },
+    "statusCode": 400,
+    "mensagemEsperada": "Usuário remetente ou destinatário não encontrado"
+  },
+  {
+    "nomeDoTeste": "Campo 'to' excede 50 caracteres",
+    "postTransfer": {
+      "from": "julio",
+      "to": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "value": 100
+    },
+    "statusCode": 400,
+    "mensagemEsperada": "Usuário remetente ou destinatário não encontrado"
+  },
+  {
+    "nomeDoTeste": "Valor como string inválida",
+    "postTransfer": {
+      "from": "julio",
+      "to": "priscila",
+      "value": "cem"
+    },
+    "statusCode": 400,
+    "mensagemEsperada": "Campos obrigatórios: from, to, value"
+  }
+]

--- a/test/rest/fixture/requisicoes/transferencias/postTransferWithErrors.json
+++ b/test/rest/fixture/requisicoes/transferencias/postTransferWithErrors.json
@@ -29,4 +29,7 @@
         "statusCode": 400,
         "mensagemEsperada": "Usuário remetente ou destinatário não encontrado"
     }
+
+       
+    
 ]


### PR DESCRIPTION
Este PR implementa testes de dados baseados na heurística VADER (letra D - Dados)
para os endpoints /users e /transfers, validando:
- Tipos e formatos de dados (string, numérico, array)
- Limites e tamanhos dos campos
- Mensagens de erro esperadas

